### PR TITLE
fftw 3.3.9 [fix]

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: {{ version }}
 
 source:
-  url: http://www.fftw.org/fftw-{{ version }}.tar.gz
+  url: https://www.fftw.org/fftw-{{ version }}.tar.gz
   sha256: bf2c7ce40b04ae811af714deb512510cc2c17b9ab9d6ddcf49fe4487eea7af3d
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,12 +5,13 @@ package:
   version: {{ version }}
 
 source:
-  fn: fftw-{{ version }}.tar.gz
   url: http://www.fftw.org/fftw-{{ version }}.tar.gz
-  md5: 50145bb68a8510b5d77605f11cadf8dc
+  sha256: bf2c7ce40b04ae811af714deb512510cc2c17b9ab9d6ddcf49fe4487eea7af3d
 
 build:
-  number: 1
+  number: 2
+  run_exports:
+    - {{ pin_subpackage('fftw', max_pin='x.x') }}
 
 requirements:
   build:
@@ -20,8 +21,6 @@ requirements:
     - ninja                # [win]
     - make                 # [not win]
     - libtool              # [not win]
-  run_exports:
-    - {{ pin_subpackage('fftw', max_pin='x.x') }}
 
 test:
   commands:
@@ -54,9 +53,19 @@ test:
     {% endfor %}
 
 about:
-  home: http://fftw.org
-  license: GPL 2
+  home: https://fftw.org
+  license: GPL-2.0
+  license_file: COPYING
+  license_family: GPL
   summary: "The fastest Fourier transform in the west."
+  description: |
+    FFTW is a C subroutine library for computing the discrete Fourier transform (DFT)
+    in one or more dimensions, of arbitrary input size, and of both real and complex
+    data (as well as of even/odd data, i.e. the discrete cosine/sine transforms or
+    DCT/DST). We believe that FFTW, which is free software, should become the FFT
+    library of choice for most applications.
+  dev_url: https://github.com/FFTW/fftw3
+  doc_url: https://fftw.org/#documentation
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
fftw 3.3.9

**Destination channel:** defaults

### Links

- [PKG-4318]
- not really the repo: https://github.com/FFTW/fftw3
- home: https://fftw.org

### Explanation of changes:

- fix recipe, fix `run_exports`, bump build number


[PKG-4318]: https://anaconda.atlassian.net/browse/PKG-4318?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ