### PR TITLE
fftw 3.3.10

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -20,7 +20,7 @@ TEST_CMD="eval cd tests && make check-local && cd -"
 #
 # We build 3 different versions of fftw:
 #
-if [[ "$target_platform" == "linux-64" ]] || [[ "$target_platform" == "linux-32" ]] || [[ "$target_platform" == "osx-64" ]]; then
+if [[ "$target_platform" == "linux-64" ]] || [[ "$target_platform" == "linux-32" ]]; then
   ARCH_OPTS_SINGLE="--enable-sse --enable-sse2 --enable-avx"
   ARCH_OPTS_DOUBLE="--enable-sse2 --enable-avx"
   ARCH_OPTS_LONG_DOUBLE="--enable-long-double"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,39 +1,46 @@
-{% set version = "3.3.9" %}
+{% set name = "fftw" %}
+{% set version = "3.3.10" %}
 
 package:
-  name: fftw
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://www.fftw.org/fftw-{{ version }}.tar.gz
-  sha256: bf2c7ce40b04ae811af714deb512510cc2c17b9ab9d6ddcf49fe4487eea7af3d
+  url: https://www.fftw.org/{{ name }}-{{ version }}.tar.gz
+  sha256: 56c932549852cddcfafdab3820b0200c7742675be92179e59e6215b340e26467
+  patches:  # [win]
+    - patches/0001-patch-cmake.patch  # [win]
 
 build:
-  number: 2
+  number: 0
   run_exports:
     - {{ pin_subpackage('fftw', max_pin='x.x') }}
 
 requirements:
   build:
+    - {{ stdlib('c') }}
     - {{ compiler('c') }}
-    - perl                 # [not win]
     - cmake                # [win]
-    - ninja                # [win]
+    - ninja-base           # [win]
+    - perl                 # [not win]
     - make                 # [not win]
     - libtool              # [not win]
 
 test:
+  requires:
+    - python
   commands:
-    - exit $(test -f ${PREFIX}/lib/libfftw3f.a)          # [not win]
-    - exit $(test -f ${PREFIX}/lib/libfftw3.a)           # [not win]
-    - exit $(test -f ${PREFIX}/lib/libfftw3l.a)          # [not win]
-    - exit $(test -f ${PREFIX}/lib/libfftw3f_threads.a)  # [not win]
-    - exit $(test -f ${PREFIX}/lib/libfftw3_threads.a)   # [not win]
-    - exit $(test -f ${PREFIX}/lib/libfftw3l_threads.a)  # [not win]
+    # ARM doesn't support long double thus the skip on the libs
+    - test -f ${PREFIX}/lib/libfftw3f.a           # [not win]
+    - test -f ${PREFIX}/lib/libfftw3.a            # [not win]
+    - test -f ${PREFIX}/lib/libfftw3l.a           # [not (win or aarch64 or arm64)]
+    - test -f ${PREFIX}/lib/libfftw3f_threads.a   # [not win]
+    - test -f ${PREFIX}/lib/libfftw3_threads.a    # [not win]
+    - test -f ${PREFIX}/lib/libfftw3l_threads.a   # [not (win or aarch64 or arm64)]
 
     # Verify headers are installed
-    - test -f ${PREFIX}/include/fftw3.h                  # [not win]
-    - if not exist %LIBRARY_INC%\\fftw3.h exit 1         # [win]
+    - test -f ${PREFIX}/include/fftw3.h           # [not win]
+    - if not exist %LIBRARY_INC%\\fftw3.h exit 1  # [win]
 
     # Verify shared libraries are installed
     {% set fftw_libs = [
@@ -41,13 +48,17 @@ test:
             "libfftw3_threads",
             "libfftw3f",
             "libfftw3f_threads",
-            "libfftw3l",
-            "libfftw3l_threads",
+            "libfftw3l",          # [not (aarch64 or arm64)]
+            "libfftw3l_threads",  # [not (aarch64 or arm64)]
     ] %}
 
-    {% set fftw_libs = ["fftw3f", "fftw3"] %}
+    {% for lib in fftw_libs %}
+    - python -c "import ctypes; ctypes.cdll[r'${PREFIX}/lib/{{ lib }}${SHLIB_EXT}']"  # [unix]
+    {% endfor %}
 
-    {% for base in fftw_libs %}
+    {% set win_fftw_libs = ["fftw3f", "fftw3"] %}
+
+    {% for base in win_fftw_libs %}
     - if not exist %LIBRARY_LIB%\\{{ base }}.lib exit 1  # [win]
     - if not exist %LIBRARY_BIN%\\{{ base }}.dll exit 1  # [win]
     {% endfor %}

--- a/recipe/patches/0001-patch-cmake.patch
+++ b/recipe/patches/0001-patch-cmake.patch
@@ -1,0 +1,22 @@
+From 37ed05b99f33bd00f0db3b17a45d8ce3aea202d7 Mon Sep 17 00:00:00 2001
+From: Ivan Iziumov <iiziumov@anaconda.com>
+Date: Mon, 3 Nov 2025 17:13:05 +0100
+Subject: [PATCH] patch cmake
+
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 4d0496b1..99eeddb2 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required (VERSION 3.0)
++cmake_minimum_required(VERSION 3.10)
+ 
+ if (NOT DEFINED CMAKE_BUILD_TYPE)
+   set (CMAKE_BUILD_TYPE Release CACHE STRING "Build type")
+-- 
+2.50.1 (Apple Git-155)
+


### PR DESCRIPTION
fftw 3.3.10

**Destination channel:** Defaults

### Links

- [PKG-10304]
- dev_url:        https://github.com/FFTW/fftw3/tree/fftw-3.3.10
- conda_forge:    https://github.com/conda-forge/fftw-feedstock
- pypi:           
- pypi inspector: 

### Explanation of changes:

- new version
- OSX doesn't support long double so removed the test for it
- Added actual shared lib check
- Patched the CMake versioning for Windows build

[PKG-10304]: https://anaconda.atlassian.net/browse/PKG-10304